### PR TITLE
Adding lowercased name to the end element check

### DIFF
--- a/lib/xml-stream.js
+++ b/lib/xml-stream.js
@@ -55,6 +55,7 @@ var ExtraloadXmlStream = function(opts) {
     });
     parser.on('endElement', function(name) {
         if (nodeStack) {
+            name = name.toLowerCase();
             var node = nodeStack.pop();
             if (nodeStack.length > 0) {
                 nodeStack[nodeStack.length - 1].children.push(node);


### PR DESCRIPTION
Malformed XML error is thrown if the target node has any casing other than lowercase since the node's name is converted to lowercase when the element is opened but not when it's closed.
